### PR TITLE
add static attributes to exporter

### DIFF
--- a/x-pack/plugins/monitoring_collection/server/lib/prometheus_exporter.ts
+++ b/x-pack/plugins/monitoring_collection/server/lib/prometheus_exporter.ts
@@ -19,7 +19,7 @@ export class PrometheusExporter extends MetricReader {
   private readonly _appendTimestamp: boolean;
   private _serializer: PrometheusSerializer;
 
-  constructor(logger: Logger, config: ExporterConfig = {}) {
+  constructor(logger: Logger, config: ExporterConfig = {}, staticAttributes = {}) {
     super();
     this._prefix = config.prefix || OpenTelemetryPrometheusExporter.DEFAULT_OPTIONS.prefix;
     this._appendTimestamp =
@@ -27,7 +27,12 @@ export class PrometheusExporter extends MetricReader {
         ? config.appendTimestamp
         : OpenTelemetryPrometheusExporter.DEFAULT_OPTIONS.appendTimestamp;
 
-    this._serializer = new PrometheusSerializer(logger, this._prefix, this._appendTimestamp);
+    this._serializer = new PrometheusSerializer(
+      logger,
+      this._prefix,
+      this._appendTimestamp,
+      staticAttributes
+    );
   }
 
   selectAggregationTemporality(): AggregationTemporality {

--- a/x-pack/plugins/monitoring_collection/server/lib/prometheus_serializer.ts
+++ b/x-pack/plugins/monitoring_collection/server/lib/prometheus_serializer.ts
@@ -175,13 +175,15 @@ export class PrometheusSerializer {
   private logger: Logger;
   private _prefix: string | undefined;
   private _appendTimestamp: boolean;
+  private _staticAttributes: Record<string, string>;
 
-  constructor(logger: Logger, prefix?: string, appendTimestamp = true) {
+  constructor(logger: Logger, prefix?: string, appendTimestamp = true, staticAttributes = {}) {
     if (prefix) {
       this._prefix = prefix + '_';
     }
     this._appendTimestamp = appendTimestamp;
     this.logger = logger;
+    this._staticAttributes = staticAttributes;
   }
 
   serialize(resourceMetrics: ResourceMetrics): string {
@@ -248,7 +250,7 @@ export class PrometheusSerializer {
     const timestamp = hrTimeToMilliseconds(dataPoint.endTime);
     results += stringify(
       name,
-      attributes,
+      { ...attributes, ...this._staticAttributes },
       value,
       this._appendTimestamp ? timestamp : undefined,
       undefined

--- a/x-pack/plugins/monitoring_collection/server/lib/prometheus_serializer.ts
+++ b/x-pack/plugins/monitoring_collection/server/lib/prometheus_serializer.ts
@@ -272,7 +272,7 @@ export class PrometheusSerializer {
     for (const key of ['count', 'sum'] as Array<'count' | 'sum'>) {
       results += stringify(
         name + '_' + key,
-        attributes,
+        { ...attributes, ...this._staticAttributes },
         value[key],
         this._appendTimestamp ? timestamp : undefined,
         undefined
@@ -299,7 +299,7 @@ export class PrometheusSerializer {
       }
       results += stringify(
         name + '_bucket',
-        attributes,
+        { ...attributes, ...this._staticAttributes },
         cumulativeSum,
         this._appendTimestamp ? timestamp : undefined,
         {

--- a/x-pack/plugins/monitoring_collection/server/plugin.ts
+++ b/x-pack/plugins/monitoring_collection/server/plugin.ts
@@ -155,7 +155,11 @@ export class MonitoringCollectionPlugin implements Plugin<MonitoringCollectionSe
     if (this.config.opentelemetry?.metrics.prometheus.enabled) {
       // Add Prometheus exporter
       this.logger.debug(`Starting prometheus exporter at ${PROMETHEUS_ROUTE}`);
-      this.prometheusExporter = new PrometheusExporter(this.logger);
+      this.prometheusExporter = new PrometheusExporter(this.logger, undefined, {
+        serviceName,
+        serviceInstanceId,
+        serviceVersion,
+      });
       meterProvider.addMetricReader(this.prometheusExporter);
     }
   }


### PR DESCRIPTION
## Summary

Stacked on https://github.com/elastic/kibana/pull/133171

Prometheus exporter currently does not support resource attributes. While you can define these attributes, the serializer will simply ignore them and the downstream collection won't be able to provide host/service context to the ingested metrics. 
This is a workaround that adds a concept of static attributes that will be passed to each metric during serialization.

---

HTTP output
```
[12:36:15] kibana git:(otel-metrics-static-attributes*) $ curl http://elastic:changeme@localhost:5601/pat/api/monitoring_collection/v1/prometheus
# HELP ruleExecutionsTotal_total description missing
# TYPE ruleExecutionsTotal_total counter
ruleExecutionsTotal_total{serviceName="kevins-macbook-pro.home",serviceInstanceId="5b2de169-2785-441b-ae8c-186a1936b17d",serviceVersion="8.4.0"} 7 1658226977569
# HELP ruleExecutions_total description missing
# TYPE ruleExecutions_total counter
ruleExecutions_total{ruleType="monitoring_alert_thread_pool_search_rejections",serviceName="kevins-macbook-pro.home",serviceInstanceId="5b2de169-2785-441b-ae8c-186a1936b17d",serviceVersion="8.4.0"} 1 1658226977569
ruleExecutions_total{ruleType="monitoring_alert_nodes_changed",serviceName="kevins-macbook-pro.home",serviceInstanceId="5b2de169-2785-441b-ae8c-186a1936b17d",serviceVersion="8.4.0"} 1 1658226977569
ruleExecutions_total{ruleType="monitoring_alert_cpu_usage",serviceName="kevins-macbook-pro.home",serviceInstanceId="5b2de169-2785-441b-ae8c-186a1936b17d",serviceVersion="8.4.0"} 1 1658226977569
ruleExecutions_total{ruleType="monitoring_shard_size",serviceName="kevins-macbook-pro.home",serviceInstanceId="5b2de169-2785-441b-ae8c-186a1936b17d",serviceVersion="8.4.0"} 1 1658226977569
ruleExecutions_total{ruleType="monitoring_alert_thread_pool_write_rejections",serviceName="kevins-macbook-pro.home",serviceInstanceId="5b2de169-2785-441b-ae8c-186a1936b17d",serviceVersion="8.4.0"} 1 1658226977569
ruleExecutions_total{ruleType="monitoring_ccr_read_exceptions",serviceName="kevins-macbook-pro.home",serviceInstanceId="5b2de169-2785-441b-ae8c-186a1936b17d",serviceVersion="8.4.0"} 1 1658226977569
ruleExecutions_total{ruleType="monitoring_alert_cluster_health",serviceName="kevins-macbook-pro.home",serviceInstanceId="5b2de169-2785-441b-ae8c-186a1936b17d",serviceVersion="8.4.0"} 1 1658226977569
# HELP ruleFailures_total description missing
# TYPE ruleFailures_total counter
# HELP ruleDuration description missing
# TYPE ruleDuration histogram
ruleDuration_count{serviceName="kevins-macbook-pro.home",serviceInstanceId="5b2de169-2785-441b-ae8c-186a1936b17d",serviceVersion="8.4.0"} 7 1658226977569
ruleDuration_sum{serviceName="kevins-macbook-pro.home",serviceInstanceId="5b2de169-2785-441b-ae8c-186a1936b17d",serviceVersion="8.4.0"} 2658 1658226977569
ruleDuration_bucket{serviceName="kevins-macbook-pro.home",serviceInstanceId="5b2de169-2785-441b-ae8c-186a1936b17d",serviceVersion="8.4.0",le="0"} 0 1658226977569
ruleDuration_bucket{serviceName="kevins-macbook-pro.home",serviceInstanceId="5b2de169-2785-441b-ae8c-186a1936b17d",serviceVersion="8.4.0",le="5"} 0 1658226977569
ruleDuration_bucket{serviceName="kevins-macbook-pro.home",serviceInstanceId="5b2de169-2785-441b-ae8c-186a1936b17d",serviceVersion="8.4.0",le="10"} 0 1658226977569
ruleDuration_bucket{serviceName="kevins-macbook-pro.home",serviceInstanceId="5b2de169-2785-441b-ae8c-186a1936b17d",serviceVersion="8.4.0",le="25"} 0 1658226977569
ruleDuration_bucket{serviceName="kevins-macbook-pro.home",serviceInstanceId="5b2de169-2785-441b-ae8c-186a1936b17d",serviceVersion="8.4.0",le="50"} 0 1658226977569
ruleDuration_bucket{serviceName="kevins-macbook-pro.home",serviceInstanceId="5b2de169-2785-441b-ae8c-186a1936b17d",serviceVersion="8.4.0",le="75"} 0 1658226977569
ruleDuration_bucket{serviceName="kevins-macbook-pro.home",serviceInstanceId="5b2de169-2785-441b-ae8c-186a1936b17d",serviceVersion="8.4.0",le="100"} 0 1658226977569
ruleDuration_bucket{serviceName="kevins-macbook-pro.home",serviceInstanceId="5b2de169-2785-441b-ae8c-186a1936b17d",serviceVersion="8.4.0",le="250"} 0 1658226977569
ruleDuration_bucket{serviceName="kevins-macbook-pro.home",serviceInstanceId="5b2de169-2785-441b-ae8c-186a1936b17d",serviceVersion="8.4.0",le="500"} 7 1658226977569
ruleDuration_bucket{serviceName="kevins-macbook-pro.home",serviceInstanceId="5b2de169-2785-441b-ae8c-186a1936b17d",serviceVersion="8.4.0",le="1000"} 7 1658226977569
ruleDuration_bucket{serviceName="kevins-macbook-pro.home",serviceInstanceId="5b2de169-2785-441b-ae8c-186a1936b17d",serviceVersion="8.4.0",le="+Inf"} 7 1658226977569
```

---
Ingested document

<img width="855" alt="Screenshot 2022-07-19 at 12 27 43" src="https://user-images.githubusercontent.com/5239883/179729430-2e40d531-00af-44dd-b2f7-1c4bcdde30fd.png">

